### PR TITLE
Switch to 32 bit

### DIFF
--- a/moodlemlbackend/model/tensor.py
+++ b/moodlemlbackend/model/tensor.py
@@ -86,6 +86,7 @@ class TF(object):
 
     def build_graph(self, initial_weights=False):
         """Builds the computational graph without feeding any data in"""
+        tf.compat.v1.reset_default_graph()
 
         # Placeholders for input values.
         with tf.name_scope('inputs'):

--- a/moodlemlbackend/model/tensor.py
+++ b/moodlemlbackend/model/tensor.py
@@ -202,6 +202,7 @@ class TF(object):
         # work with multiple classes.
         y = preprocessing.MultiLabelBinarizer().fit_transform(
             y.reshape(len(y), 1))
+        y = y.astype(np.float32)
 
         # floats division otherwise we get 0 if n_examples is lower than the
         # batch size and minimum 1 iteration.

--- a/moodlemlbackend/model/tensor.py
+++ b/moodlemlbackend/model/tensor.py
@@ -90,30 +90,30 @@ class TF(object):
         # Placeholders for input values.
         with tf.name_scope('inputs'):
             self.x = tf.placeholder(
-                tf.float64, [None, self.n_features], name='x')
+                tf.float32, [None, self.n_features], name='x')
             self.y_ = tf.placeholder(
-                tf.float64, [None, self.n_classes], name='dataset-y')
+                tf.float32, [None, self.n_classes], name='dataset-y')
 
         # Variables for computed stuff, we need to initialise them now.
         with tf.name_scope('initialise-vars'):
 
             if initial_weights is False:
                 initial_w_hidden = tf.random_normal(
-                    [self.n_features, self.n_hidden], dtype=tf.float64)
+                    [self.n_features, self.n_hidden], dtype=tf.float32)
                 initial_w_output = tf.random_normal(
-                    [self.n_hidden, self.n_classes], dtype=tf.float64)
+                    [self.n_hidden, self.n_classes], dtype=tf.float32)
                 initial_b_hidden = tf.random_normal(
-                    [self.n_hidden], dtype=tf.float64)
+                    [self.n_hidden], dtype=tf.float32)
                 initial_b_output = tf.random_normal(
-                    [self.n_classes], dtype=tf.float64)
+                    [self.n_classes], dtype=tf.float32)
             else:
-                initial_w_hidden = np.float64(
+                initial_w_hidden = np.float32(
                     initial_weights['initialise-vars/input-to-hidden-weights'])
-                initial_w_output = np.float64(
+                initial_w_output = np.float32(
                     initial_weights['initialise-vars/hidden-to-output-weights'])
-                initial_b_hidden = np.float64(
+                initial_b_hidden = np.float32(
                     initial_weights['initialise-vars/hidden-bias'])
-                initial_b_output = np.float64(
+                initial_b_output = np.float32(
                     initial_weights['initialise-vars/output-bias'])
 
             W = {

--- a/moodlemlbackend/model/tensor.py
+++ b/moodlemlbackend/model/tensor.py
@@ -234,9 +234,9 @@ class TF(object):
                 index = index + 1
 
     def predict(self, x):
-        """Returns predictions"""
+        """Find the index of the most probable class."""
         return self.sess.run(tf.argmax(self.y, 1), {self.x: x})
 
     def predict_proba(self, x):
-        """Returns predicted probabilities"""
-        return self.sess.run(self.probs, {self.x: x})
+        """Find the probability distribution over all classes."""
+        return self.sess.run(tf.concat(self.y, 1), {self.x: x})

--- a/moodlemlbackend/processor/estimator.py
+++ b/moodlemlbackend/processor/estimator.py
@@ -107,7 +107,7 @@ class Estimator(object):
         """Extracts labelled samples from the provided data file"""
 
         # We skip 3 rows of metadata.
-        samples = np.genfromtxt(filepath, delimiter=',', dtype='float',
+        samples = np.genfromtxt(filepath, delimiter=',', dtype=np.float32,
                                 skip_header=3, missing_values='',
                                 filling_values=False)
         samples = shuffle(samples)
@@ -139,7 +139,7 @@ class Estimator(object):
         # We don't know the number of columns, we can only get them all and
         # discard the first one.
         samples = np.genfromtxt(filepath, delimiter=',',
-                                dtype=float, skip_header=3,
+                                dtype=np.float32, skip_header=3,
                                 missing_values='', filling_values=False)
 
         # This is a single sample dataset, genfromtxt returns the samples

--- a/moodlemlbackend/processor/estimator.py
+++ b/moodlemlbackend/processor/estimator.py
@@ -109,7 +109,7 @@ class Estimator(object):
         # We skip 3 rows of metadata.
         samples = np.genfromtxt(filepath, delimiter=',', dtype=np.float32,
                                 skip_header=3, missing_values='',
-                                filling_values=False)
+                                filling_values=0.0)
         samples = shuffle(samples)
 
         # This is a single sample dataset, genfromtxt returns the samples


### PR DESCRIPTION
The extra precision of 64 bit floats is not useful for machine learning, and this is especially true for Moodle's use, since most of the inputs are effectively one bit, the networks are small and shallow, and the functions being learned are quite vague.

As a result of 64 bit being generally unused, the 64 bit routines are much less well optimised than the 32 bit ones, and combined with the inherent throughput and caching benefits, we see 32 bit training being many times faster than 64 bit.

The other significant change here is to report actual probabilities rather than the logit values which are not really meaningful.
